### PR TITLE
controller: Execute SyncServiceJobs right away on initial sync

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -188,6 +188,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 	if ok := cache.WaitForCacheSync(stopCh, c.servicesSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
+	klog.Info("Informer caches are synchronized, enqueueing job to remove the cleanup barrier")
 	// we now enqueue a barrier clear job, as well as a cleanup job
 	c.worker.EnqueueJob(&RemoveCleanupBarrierJob{})
 	c.worker.EnqueueJob(&CleanupJob{})


### PR DESCRIPTION
controller: Execute SyncServiceJobs right away on initial sync

This avoids going through the queue, which appears to be re-ordering
jobs. The evidence for this has been collected in #30, but I'll try to
summarize it here. We see the following logs:

```
W0621 08:49:17.637865       1 client_config.go:617] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0621 08:49:18.750799       1 controller.go:113] Setting up event handlers
I0621 08:49:18.752439       1 controller.go:182] Starting Load Balancer controller
I0621 08:49:18.757767       1 controller.go:185] Waiting for informer caches to sync
I0621 08:49:18.837646       1 controller.go:224] handleObject called
I0621 08:49:18.837667       1 controller.go:229] Processing object: monitoring/prometheus-stack-prometheus-node-exporter
[…]
I0621 08:49:18.841761       1 controller.go:229] Processing object: monitoring/prometheus-adapter
I0621 08:49:18.842126       1 controller.go:224] handleObject called
[…]
I0621 08:49:18.840476       1 controller.go:224] handleObject called
I0621 08:49:18.840516       1 controller.go:229] Processing object: k8s-svc-ingress/ingress-ingress-nginx-controller-admission
[…]
I0621 08:49:18.930515       1 controller.go:224] handleObject called
I0621 08:49:18.930578       1 controller.go:229] Processing object: k8s-svc-ingress/ingress-ingress-nginx-controller
I0621 08:49:18.932766       1 controller.go:224] handleObject called
I0621 08:49:18.932808       1 controller.go:229] Processing object: kube-system/ch-k8s-lbaas-controller
I0621 08:49:18.930315       1 controller.go:193] Starting workers
I0621 08:49:18.932896       1 controller.go:204] Started workers
I0621 08:49:18.932944       1 controller.go:212] Triggering periodic cleanup
I0621 08:49:18.933026       1 worker.go:277] Worker started
I0621 08:49:25.401770       1 worker.go:306] Successfully executed job UpdateConfigJob
I0621 08:49:25.401879       1 worker.go:306] Successfully executed job SyncServiceJob("monitoring/prometheus-stack-prometheus-node-exporter")
[…]
I0621 08:49:25.404497       1 worker.go:306] Successfully executed job SyncServiceJob("monitoring/prometheus-adapter")
I0621 08:49:25.404634       1 worker.go:306] Successfully executed job RemoveCleanupBarrier
I0621 08:49:25.680933       1 port_manager.go:239] Used ports=[]
I0621 08:49:25.681074       1 port_manager.go:255] Trying to delete port "90bc1474-e1ed-4d58-87b7-3d281ff0a191"
I0621 08:49:28.298263       1 port_manager.go:224] Trying to delete floating ip "5b0463e4-7c70-4c66-af46-6f2a204c8032"
I0621 08:49:29.162748       1 worker.go:306] Successfully executed job CleanupJob
I0621 08:49:29.163014       1 worker.go:306] Successfully executed job SyncServiceJob("k8s-svc-cert-manager/cert-manager-webhook")
```

The RemoveCleanupBarrier and CleanupJob are enqueued right before
`Starting workers`. Yet, we can see that they are executed in the middle
of a series of jobs enqueued between `Waiting for informer caches to
sync` and `Starting workers`.

There are only two explanations:

- WaitForCacheSync (controller.go:186) returns before all calls to
  handleObject have proceeded and then code between :186 and :193 takes
  more than 0.5 seconds to execute (difference between the timestamp at
  which `SyncServiceJob("monitoring/prometheus-adapter")` is enqueued
  and the timestamp of the `Starting workers` log message).

  In this case, the order in the queue would be incorrect, but at least
  unaltered by the queue. Thanks to the additional log message in line 189,
  we will be able to find this out, too.

- The queue is actually reordering the entries. That would be weird for
  a queue and from a quick glance at the code of the queue, I cannot
  find how it would do that. But chances are I missed something, because
  "generic" golang code is dark and full of indirections.

Either way, this should fix the loss of IPs for good.

Fixes #30.
