### PR TITLE
Scope IP and Port listings to current project

### DIFF
--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -64,8 +64,9 @@ type Config struct {
 }
 
 type OpenStackClient struct {
-	provider *gophercloud.ProviderClient
-	region   string
+	provider  *gophercloud.ProviderClient
+	region    string
+	projectID string
 }
 
 func (cfg AuthOpts) ToAuthOptions() gophercloud.AuthOptions {
@@ -144,8 +145,9 @@ func NewClient(cfg *AuthOpts) (*OpenStackClient, error) {
 	}
 
 	return &OpenStackClient{
-		provider: provider,
-		region:   cfg.Region,
+		provider:  provider,
+		region:    cfg.Region,
+		projectID: cfg.ProjectID,
 	}, nil
 }
 

--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	netutil "k8s.io/apimachinery/pkg/util/net"
@@ -144,10 +145,18 @@ func NewClient(cfg *AuthOpts) (*OpenStackClient, error) {
 		return nil, err
 	}
 
+	projectID := cfg.ProjectID
+	if projectID == "" {
+		projectID, err = getProjectID(provider)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &OpenStackClient{
 		provider:  provider,
 		region:    cfg.Region,
-		projectID: cfg.ProjectID,
+		projectID: projectID,
 	}, nil
 }
 
@@ -155,4 +164,24 @@ func (client *OpenStackClient) NewNetworkV2() (*gophercloud.ServiceClient, error
 	return openstack.NewNetworkV2(client.provider, gophercloud.EndpointOpts{
 		Region: client.region,
 	})
+}
+
+// Extract project ID from the provider client authentication result.
+func getProjectID(provider *gophercloud.ProviderClient) (string, error) {
+	authResult := provider.GetAuthResult()
+	if authResult == nil {
+		return "", fmt.Errorf("no AuthResult from provider client")
+	}
+
+	// We expect only identity v3 tokens
+	token, ok := authResult.(tokens3.CreateResult)
+	if !ok {
+		return "", fmt.Errorf("unexpected AuthResult type %t", authResult)
+	}
+
+	project, err := token.ExtractProject()
+	if err != nil {
+		return "", err
+	}
+	return project.ID, nil
 }

--- a/internal/openstack/port_manager.go
+++ b/internal/openstack/port_manager.go
@@ -63,6 +63,7 @@ func (opts CustomCreateOpts) ToPortCreateMap() (map[string]interface{}, error) {
 type OpenStackL3PortManager struct {
 	client    *gophercloud.ServiceClient
 	networkID string
+	projectID string
 	cfg       *NetworkingOpts
 	ports     PortClient
 }
@@ -84,10 +85,12 @@ func (client *OpenStackClient) NewOpenStackL3PortManager(networkConfig *Networki
 		client:    networkingclient,
 		cfg:       networkConfig,
 		networkID: networkID,
+		projectID: client.projectID,
 		ports: NewPortClient(
 			networkingclient,
 			TagLBManagedPort,
 			networkConfig.UseFloatingIPs,
+			client.projectID,
 		),
 	}, nil
 }
@@ -205,7 +208,8 @@ func (pm *OpenStackL3PortManager) deleteUnusedFloatingIPs() error {
 	pager := floatingipsv2.List(
 		pm.client,
 		floatingipsv2.ListOpts{
-			Tags: TagLBManagedPort,
+			Tags:      TagLBManagedPort,
+			ProjectID: pm.projectID,
 		},
 	)
 


### PR DESCRIPTION
The Neutron API will list resources from all Projects that the user has access too, not just the current project.
This patch adds the current project as a filter to the Port and Floating IP listings to avoid interference with other projects.

Fixes #49