### PR TITLE
[agent] Adjust policy handling for IPv6 addresses

### DIFF
--- a/internal/agent/nftables_generator_test.go
+++ b/internal/agent/nftables_generator_test.go
@@ -158,6 +158,18 @@ func TestNftablesStructuredConfigFromNonEmptyLBModel(t *testing.T) {
 					"block-range",
 				},
 			},
+			{
+				Address: "ff00::1",
+				NetworkPolicies: []string{
+					"allow-http",
+				},
+			},
+			{
+				Address: "ff00::2",
+				NetworkPolicies: []string{
+					"block-range",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
a chain name must not contain colons, otherwise reloading nftables fails due to syntax errors. IPv6 addresses do contain a lot of colons. For simplicity, these are replaced by dashes for chain names.

Futhermore we must set the proper protocol in the rule depending on the IP familiy.