### PR TITLE
Various docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# ch-k8s-lbaas
+
+## Documentation
+
+Documentation for the project is available at https://cloudandheat.github.io/ch-k8s-lbaas/

--- a/docs/controller/port_manager.md
+++ b/docs/controller/port_manager.md
@@ -30,6 +30,8 @@ A simple implementation that just has a static list of IP-addresses that can be 
 
 A more complex implementation that can be used if the load-balancer gateways are running on OpenStack.
 
+Running multiple ch-k8s-lbaas instances that manage resources within the same OpenStack project is not supported, there will be collisions.
+
 - Able to create new OpenStack ports with floating-IPs
 - The ID of the L3-port is the OpenStack port ID (UUID)
 - Unused L3-ports can be deleted using the cleanup function

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-Alternatively to the steps below, LBaaS can be deployed as part of [yaook-k8s](https://yaook.gitlab.io/k8s/quick-start.html ) on OpenStack.
+Alternatively to the steps below, LBaaS can be deployed as part of [Tarook](https://docs.tarook.cloud/devel/user/guide/quick-start/index.html) on OpenStack.
 
 ## Requirements
 


### PR DESCRIPTION
- add README with link so that docs are discoverable
- yaook/k8s was renamed to Tarook
- document limitation on OpenStack projects, see #58 

Part of https://gitlab.com/alasca.cloud/focis/meta/-/work_items/111